### PR TITLE
Add DB client libraries for PostgreSQL and MariaDB

### DIFF
--- a/docker/7.3/Dockerfile
+++ b/docker/7.3/Dockerfile
@@ -191,6 +191,15 @@ RUN --mount=type=cache,target=/var/cache/apt \
     set -eux; \
     cd /tmp; \
     # ---
+    # Database clients (PostgreSQL, MariaDB/MySQL)
+    { \
+        apt-get update; \
+        apt-get install --no-install-recommends -y \
+            mariadb-client \
+            postgresql-client \
+        ; \
+    }; \
+    # ---
     # Composer (needs 7z, unzip)
     { \
         apt-get update; \

--- a/docker/7.3/goss.yaml
+++ b/docker/7.3/goss.yaml
@@ -50,6 +50,22 @@ command:
     exec: "yarn --version"
     exit-status: 0
 
+  mysql-installed:
+    exec: "mysql --version"
+    exit-status: 0
+
+  mysqldump-installed:
+    exec: "mysqldump --version"
+    exit-status: 0
+
+  pg_dump-installed:
+    exec: "pg_dump --version"
+    exit-status: 0
+
+  pg_restore-installed:
+    exec: "pg_restore --version"
+    exit-status: 0
+
 file:
   /usr/local/bin/fixuid:
     exists: true

--- a/docker/7.4/Dockerfile
+++ b/docker/7.4/Dockerfile
@@ -192,6 +192,15 @@ RUN --mount=type=cache,target=/var/cache/apt \
     set -eux; \
     cd /tmp; \
     # ---
+    # Database clients (PostgreSQL, MariaDB/MySQL)
+    { \
+        apt-get update; \
+        apt-get install --no-install-recommends -y \
+            mariadb-client \
+            postgresql-client \
+        ; \
+    }; \
+    # ---
     # Composer (needs 7z, unzip)
     { \
         apt-get update; \

--- a/docker/7.4/goss.yaml
+++ b/docker/7.4/goss.yaml
@@ -50,6 +50,22 @@ command:
     exec: "yarn --version"
     exit-status: 0
 
+  mysql-installed:
+    exec: "mysql --version"
+    exit-status: 0
+
+  mysqldump-installed:
+    exec: "mysqldump --version"
+    exit-status: 0
+
+  pg_dump-installed:
+    exec: "pg_dump --version"
+    exit-status: 0
+
+  pg_restore-installed:
+    exec: "pg_restore --version"
+    exit-status: 0
+
 file:
   /usr/local/bin/fixuid:
     exists: true

--- a/docker/8.0/Dockerfile
+++ b/docker/8.0/Dockerfile
@@ -190,6 +190,15 @@ RUN --mount=type=cache,target=/var/cache/apt \
     set -eux; \
     cd /tmp; \
     # ---
+    # Database clients (PostgreSQL, MariaDB/MySQL)
+    { \
+        apt-get update; \
+        apt-get install --no-install-recommends -y \
+            mariadb-client \
+            postgresql-client \
+        ; \
+    }; \
+    # ---
     # Composer (needs 7z, unzip)
     { \
         apt-get update; \

--- a/docker/8.0/goss.yaml
+++ b/docker/8.0/goss.yaml
@@ -50,6 +50,22 @@ command:
     exec: "yarn --version"
     exit-status: 0
 
+  mysql-installed:
+    exec: "mysql --version"
+    exit-status: 0
+
+  mysqldump-installed:
+    exec: "mysqldump --version"
+    exit-status: 0
+
+  pg_dump-installed:
+    exec: "pg_dump --version"
+    exit-status: 0
+
+  pg_restore-installed:
+    exec: "pg_restore --version"
+    exit-status: 0
+
 file:
   /usr/local/bin/fixuid:
     exists: true

--- a/docker/8.1/Dockerfile
+++ b/docker/8.1/Dockerfile
@@ -193,6 +193,15 @@ RUN --mount=type=cache,target=/var/cache/apt \
     set -eux; \
     cd /tmp; \
     # ---
+    # Database clients (PostgreSQL, MariaDB/MySQL)
+    { \
+        apt-get update; \
+        apt-get install --no-install-recommends -y \
+            mariadb-client \
+            postgresql-client \
+        ; \
+    }; \
+    # ---
     # Composer (needs 7z, unzip)
     { \
         apt-get update; \

--- a/docker/8.1/goss.yaml
+++ b/docker/8.1/goss.yaml
@@ -50,6 +50,22 @@ command:
     exec: "yarn --version"
     exit-status: 0
 
+  mysql-installed:
+    exec: "mysql --version"
+    exit-status: 0
+
+  mysqldump-installed:
+    exec: "mysqldump --version"
+    exit-status: 0
+
+  pg_dump-installed:
+    exec: "pg_dump --version"
+    exit-status: 0
+
+  pg_restore-installed:
+    exec: "pg_restore --version"
+    exit-status: 0
+
 file:
   /usr/local/bin/fixuid:
     exists: true


### PR DESCRIPTION
Facilitate dump/restore operations via PostgreSQL and MariaDB client tools (pg_dump, pg_restore, mysqldump, mysql, respectively).

This aims to help those using `artisan schema:dump` on their workflow or similar tool that help with saving and loading database snapshots.