### PR TITLE
Add sockets ext

### DIFF
--- a/docker/7.3/Dockerfile
+++ b/docker/7.3/Dockerfile
@@ -99,8 +99,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
     #
     # Ref: https://github.com/mlocati/docker-php-extension-installer
     export \
-      PHP_EXT_INSTALLER_VERSION=1.5.11 \
-      PHP_EXT_INSTALLER_SHA256SUM=bc80e8fb6da789e937095330a3568b5dbfdbb61061133bf5bcaa1e1b58b55992 \
+      PHP_EXT_INSTALLER_VERSION=1.5.16 \
+      PHP_EXT_INSTALLER_SHA256SUM=bcba747520fdaddde89faed7164c97fec5372047758e1d3a5a84952912921869 \
     ; \
     cd /tmp; \
     { \

--- a/docker/7.4/Dockerfile
+++ b/docker/7.4/Dockerfile
@@ -99,8 +99,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
     #
     # Ref: https://github.com/mlocati/docker-php-extension-installer
     export \
-      PHP_EXT_INSTALLER_VERSION=1.5.11 \
-      PHP_EXT_INSTALLER_SHA256SUM=bc80e8fb6da789e937095330a3568b5dbfdbb61061133bf5bcaa1e1b58b55992 \
+      PHP_EXT_INSTALLER_VERSION=1.5.16 \
+      PHP_EXT_INSTALLER_SHA256SUM=bcba747520fdaddde89faed7164c97fec5372047758e1d3a5a84952912921869 \
     ; \
     cd /tmp; \
     { \

--- a/docker/8.0/Dockerfile
+++ b/docker/8.0/Dockerfile
@@ -98,8 +98,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
     #
     # Ref: https://github.com/mlocati/docker-php-extension-installer
     export \
-      PHP_EXT_INSTALLER_VERSION=1.5.11 \
-      PHP_EXT_INSTALLER_SHA256SUM=bc80e8fb6da789e937095330a3568b5dbfdbb61061133bf5bcaa1e1b58b55992 \
+      PHP_EXT_INSTALLER_VERSION=1.5.16 \
+      PHP_EXT_INSTALLER_SHA256SUM=bcba747520fdaddde89faed7164c97fec5372047758e1d3a5a84952912921869 \
     ; \
     cd /tmp; \
     { \

--- a/docker/8.0/Dockerfile
+++ b/docker/8.0/Dockerfile
@@ -124,6 +124,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
       pdo_mysql \
       pdo_pgsql \
       redis-stable \
+      sockets \
       xdebug-stable \
       xsl \
       zip \

--- a/docker/8.0/goss.yaml
+++ b/docker/8.0/goss.yaml
@@ -26,6 +26,7 @@ command:
       - "/pdo_mysql/"
       - "/pdo_pgsql/"
       - "/redis/"
+      - "/sockets/"
       - "/tokenizer/"
       - "/xdebug/"
       - "/xml/"

--- a/docker/8.1/Dockerfile
+++ b/docker/8.1/Dockerfile
@@ -127,6 +127,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
       pdo_mysql \
       pdo_pgsql \
       redis-stable \
+      sockets \
       xdebug-stable \
       xsl \
       zip \

--- a/docker/8.1/Dockerfile
+++ b/docker/8.1/Dockerfile
@@ -100,8 +100,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
     #
     # Ref: https://github.com/mlocati/docker-php-extension-installer
     export \
-      PHP_EXT_INSTALLER_VERSION=1.5.11 \
-      PHP_EXT_INSTALLER_SHA256SUM=bc80e8fb6da789e937095330a3568b5dbfdbb61061133bf5bcaa1e1b58b55992 \
+      PHP_EXT_INSTALLER_VERSION=1.5.16 \
+      PHP_EXT_INSTALLER_SHA256SUM=bcba747520fdaddde89faed7164c97fec5372047758e1d3a5a84952912921869 \
       IPE_GD_WITHOUTAVIF=1 \
     ; \
     cd /tmp; \

--- a/docker/8.1/goss.yaml
+++ b/docker/8.1/goss.yaml
@@ -26,6 +26,7 @@ command:
       - "/pdo_mysql/"
       - "/pdo_pgsql/"
       - "/redis/"
+      - "/sockets/"
       - "/tokenizer/"
       - "/xdebug/"
       - "/xml/"


### PR DESCRIPTION
Include sockets extension on both PHP 8.0 and 8.1 to facilitate the possible usage of RoadRunner and Laravel Octane.

Note: older versions of PHP not considered due no longer being in active support (7.4 in security fixes only, 7.3 already reached EOL).