### PR TITLE
Increases memory limit to 512MB

### DIFF
--- a/docker/8.0/Dockerfile
+++ b/docker/8.0/Dockerfile
@@ -93,6 +93,11 @@ RUN --mount=type=cache,sharing=private,target=/var/cache/apt \
     # Configure PHP in development mode
     cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"; \
     # ---
+    # Additional tweaks for development
+    { \
+        echo "memory_limit=512M"; \
+    } | tee $PHP_INI_DIR/conf.d/zz-hydrofoil-tweaks.ini; \
+    # ---
     # Use `docker-php-ext-install` to ease installation of PHP
     # extensions
     #

--- a/docker/8.0/goss.yaml
+++ b/docker/8.0/goss.yaml
@@ -39,6 +39,12 @@ command:
     stdout:
       - string(27) "This is the Euro symbol €"
 
+  validate-php-ini-tweaks:
+    exec: "php -i"
+    exit-status: 0
+    stdout:
+      - "/memory_limit.*512M$/"
+
   composer-installed:
     exec: "composer --version"
     exit-status: 0

--- a/docker/8.1/Dockerfile
+++ b/docker/8.1/Dockerfile
@@ -93,6 +93,11 @@ RUN --mount=type=cache,sharing=private,target=/var/cache/apt \
     # Configure PHP in development mode
     cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"; \
     # ---
+    # Additional tweaks for development
+    { \
+        echo "memory_limit=512M"; \
+    } | tee $PHP_INI_DIR/conf.d/zz-hydrofoil-tweaks.ini; \
+    # ---
     # Use `docker-php-ext-install` to ease installation of PHP
     # extensions
     #

--- a/docker/8.1/goss.yaml
+++ b/docker/8.1/goss.yaml
@@ -39,6 +39,12 @@ command:
     stdout:
       - string(27) "This is the Euro symbol €"
 
+  validate-php-ini-tweaks:
+    exec: "php -i"
+    exit-status: 0
+    stdout:
+      - "/memory_limit.*512M$/"
+
   composer-installed:
     exec: "composer --version"
     exit-status: 0


### PR DESCRIPTION
Allow more RAM to PHP processes than the default 128MB. This is useful when dealing with packages like PHPStan or similar that will refuse to load bigger and more complex projects.

Apply this to 8.0 and 8.1 as 7.4 and 7.3 are reaching or past EOL, respectively.